### PR TITLE
fix/ CORS policy

### DIFF
--- a/API/index.js
+++ b/API/index.js
@@ -23,10 +23,18 @@ const upload = multer({ storage: multer.memoryStorage() });
 const { XMLBuilder, XMLParser } = require('fast-xml-parser');
 const { parse: csvParse } = require('csv-parse/sync');
 const { stringify: csvStringify } = require('csv-stringify/sync');
-const allowedOrigin = process.env.CORS_ORIGIN || 'http://localhost';
+const allowedOrigins = process.env.CORS_ORIGIN || ['http://localhost', 'http://localhost:5173'];
 const CRON = process.env.REFRESH_CRON || "*/15 * * * *";
-app.use(cors({ origin: allowedOrigin, credentials: true }));
-app.use(cors({ origin: 'http://localhost:5173', credentials: true }));
+app.use(cors({
+  origin: function (origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error("Not allowed by CORS"));
+    }
+  },
+  credentials: true,
+}));
 app.get('/health', (req, res) => res.json({ ok: true }));
 
 


### PR DESCRIPTION
Un serveur Express ne permet pas plusieurs configuration de CORS. Dans ton cas, il avait deux configurations mais la seconde (avec l'url localhost:5173) écrasait la première configuration. Donc toute la partie avec la gestion des CORS par des variables d'environnement était totalement ignoré. Pour autoriser plusieurs URL il faut passer par une fonction dans la configuration des CORS (ce que j'ai fait). Comme ça tu peux filer plusieurs URL autorisées et avec un .include(), vérifier l'origine. 

Avec ces modifications, tu n'a plus qu'une seul configuration de CORS, soit ça prend les CORS configurés en variable d'environnement (pour la PROD), soit ça autorise les urls ['http://localhost', 'http://localhost:5173'] (pour le dev)